### PR TITLE
ops: Add config for build client and server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,10 +41,12 @@ rand = "0.8.3"
 [[bin]]
 name = "server"
 path = "src/server.rs"
+required-features = ["native"]
 
 [[bin]]
 name = "client"
 path = "src/client.rs"
+required-features = ["native"]
 
 [[bin]]
 name = "front"


### PR DESCRIPTION
With tokio-tungstenite set to optional (required for build front target), `required-features` need to be
set to `["native"]` for build "client" and "server" target